### PR TITLE
Factor out HIV1B-specific code in the CLI interface

### DIFF
--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -5,9 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hivdb/nucamino/alignment"
+	d "github.com/hivdb/nucamino/data"
+	h "github.com/hivdb/nucamino/scorehandler/general"
+	a "github.com/hivdb/nucamino/types/amino"
 	"github.com/hivdb/nucamino/utils/fastareader"
 	"log"
 	"os"
+	"runtime"
+	"sync"
 )
 
 type Gene uint8
@@ -25,7 +30,6 @@ var GeneLookup = map[string]Gene{
 	"GP41": GP41,
 }
 
-
 type AlignmentResult struct {
 	Name   string
 	Report *alignment.AlignmentReport
@@ -33,8 +37,7 @@ type AlignmentResult struct {
 	Err    error
 }
 
-
-func WriteTSV(
+func writeTSV(
 	file *os.File, textGenes []string,
 	seqs []fastareader.Sequence, resultMap map[string][]AlignmentResult) {
 
@@ -95,7 +98,7 @@ func WriteTSV(
 	}
 }
 
-func WriteJSON(
+func writeJSON(
 	file *os.File, textGenes []string,
 	seqs []fastareader.Sequence, resultMap map[string][]AlignmentResult) {
 
@@ -119,7 +122,7 @@ func WriteJSON(
 	file.Write(result)
 }
 
-func SeqSlice2Chan(s []fastareader.Sequence, bufferSize int) chan fastareader.Sequence {
+func seqSlice2Chan(s []fastareader.Sequence, bufferSize int) chan fastareader.Sequence {
 	c := make(chan fastareader.Sequence, bufferSize)
 	go func() {
 		for _, item := range s {
@@ -128,4 +131,149 @@ func SeqSlice2Chan(s []fastareader.Sequence, bufferSize int) chan fastareader.Se
 		close(c)
 	}()
 	return c
+}
+
+type IOParameters struct {
+	InputFileName  string
+	OutputFileName string
+	OutputFormat   string
+}
+
+type AlignmentParameters struct {
+	IndelCodonOpeningBonus   int
+	IndelCodonExtensionBonus int
+	StopCodonPenalty         int
+	GapOpeningPenalty        int
+	GapExtensionPenalty      int
+}
+
+type PositionalIndelScores map[Gene]map[int]([2]int)
+
+func PerformAlignment(
+	inputFileName string,
+	outputFileName string,
+	outputFormat string,
+	textGenes []string,
+	goroutines int,
+	quiet bool,
+	alignmentParams AlignmentParameters,
+	positionalIndelScores PositionalIndelScores,
+	referenceSequences d.SequenceMap) {
+
+	// Configure runtime
+	runtime.LockOSThread()
+	numCPU := runtime.NumCPU()
+	logger := log.New(os.Stderr, "", 0)
+	if goroutines == 0 {
+		goroutines = numCPU
+	}
+	if !quiet {
+		logger.Printf(
+			"%d CPUs were detected. %d goroutines will be created.\n",
+			numCPU, goroutines)
+	}
+
+	// Prepare input and output files
+	var input, output *os.File
+	var err error
+
+	if inputFileName == "-" {
+		input = os.Stdin
+	} else {
+		input, err = os.Open(inputFileName)
+		if err != nil {
+			logger.Fatal(err)
+			return
+		}
+	}
+	if outputFileName == "-" {
+		output = os.Stdout
+	} else {
+		output, err = os.Create(outputFileName)
+		if err != nil {
+			logger.Fatal(err)
+			return
+		}
+	}
+
+	genesCount := len(textGenes)
+	genes := make([]Gene, genesCount)
+	refs := make([][]a.AminoAcid, genesCount)
+	for i, textGene := range textGenes {
+		genes[i] = GeneLookup[textGene]
+		refs[i] = referenceSequences[textGene]
+	}
+
+	var (
+		wg         = sync.WaitGroup{}
+		seqs       = fastareader.ReadSequences(input)
+		resultChan = make(chan []AlignmentResult)
+		resultMap  = make(map[string][]AlignmentResult)
+	)
+	if !quiet {
+		logger.Printf("%d sequences were found from the input file.\n", len(seqs))
+	}
+
+	var seqChan = seqSlice2Chan(seqs, goroutines*4)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int, rChan chan<- []AlignmentResult) {
+			scoreHandlers := make([]*h.GeneralScoreHandler, genesCount)
+			for i, gene := range genes {
+				positionalIndelScores, isPositionalIndelScoreSupported := positionalIndelScores[gene]
+				scoreHandlers[i] = h.New(
+					alignmentParams.StopCodonPenalty,
+					alignmentParams.GapOpeningPenalty,
+					alignmentParams.GapExtensionPenalty,
+					alignmentParams.IndelCodonOpeningBonus,
+					alignmentParams.IndelCodonExtensionBonus,
+					positionalIndelScores,
+					isPositionalIndelScoreSupported)
+			}
+			for seq := range seqChan {
+				isSimpleAlignment := true
+				result := make([]AlignmentResult, genesCount)
+				for i := 0; i < genesCount; i++ {
+					aligned, err := alignment.NewAlignment(seq.Sequence, refs[i], scoreHandlers[i])
+					if err != nil {
+						result[i] = AlignmentResult{seq.Name, nil, err.Error(), err}
+					} else {
+						r := aligned.GetReport()
+						result[i] = AlignmentResult{seq.Name, r, "", nil}
+						isSimpleAlignment = isSimpleAlignment && r.IsSimpleAlignment
+					}
+				}
+				rChan <- result
+				if !quiet {
+					if isSimpleAlignment {
+						fmt.Fprintf(os.Stderr, ":")
+					} else {
+						fmt.Fprintf(os.Stderr, ".")
+					}
+				}
+			}
+			wg.Done()
+		}(i, resultChan)
+	}
+	go func(rChan chan<- []AlignmentResult) {
+		wg.Wait()
+		if !quiet {
+			logger.Printf("\n")
+		}
+		close(rChan)
+	}(resultChan)
+	for result := range resultChan {
+		resultMap[result[0].Name] = result
+	}
+	switch outputFormat {
+	case "tsv":
+		writeTSV(output, textGenes, seqs, resultMap)
+		break
+	case "json":
+		writeJSON(output, textGenes, seqs, resultMap)
+		break
+	}
+	if !quiet && outputFileName != "-" {
+		logger.Printf("Created alignment result file %s.", outputFileName)
+	}
 }

--- a/cli/cli/cli.go
+++ b/cli/cli/cli.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/hivdb/nucamino/alignment"
+	"github.com/hivdb/nucamino/utils/fastareader"
+	"log"
+	"os"
+)
+
+type Gene uint8
+
+const (
+	// hiv1b genes
+	GAG Gene = iota
+	POL
+	GP41
+)
+
+var GeneLookup = map[string]Gene{
+	"GAG":  GAG,
+	"POL":  POL,
+	"GP41": GP41,
+}
+
+
+type AlignmentResult struct {
+	Name   string
+	Report *alignment.AlignmentReport
+	Error  string
+	Err    error
+}
+
+
+func WriteTSV(
+	file *os.File, textGenes []string,
+	seqs []fastareader.Sequence, resultMap map[string][]AlignmentResult) {
+
+	genesCount := len(textGenes)
+	file.WriteString("Sequence Name")
+	for _, textGene := range textGenes {
+		file.WriteString("\t" + textGene + " FirstAA")
+		file.WriteString("\t" + textGene + " LastAA")
+		file.WriteString("\t" + textGene + " FirstNA")
+		file.WriteString("\t" + textGene + " LastNA")
+		file.WriteString("\t" + textGene + " Mutations")
+		file.WriteString("\t" + textGene + " FrameShifts")
+	}
+	file.WriteString("\n")
+
+	for _, seq := range seqs {
+		result := resultMap[seq.Name]
+		if result == nil {
+			continue
+		}
+		file.WriteString(seq.Name)
+		for i := 0; i < genesCount; i++ {
+			err := result[i].Err
+			if err != nil {
+				file.WriteString("\tNA\tNA\tNA\tNA\tNA\tNA")
+				continue
+			}
+			r := result[i].Report
+			file.WriteString(fmt.Sprintf(
+				"\t%d\t%d\t%d\t%d\t%s\t%s",
+				r.FirstAA, r.LastAA,
+				r.FirstNA, r.LastNA,
+				func() string {
+					var muts bytes.Buffer
+					for _, mut := range r.Mutations {
+						muts.WriteString(mut.ToString())
+						muts.WriteString(",")
+					}
+					if muts.Len() > 0 {
+						muts.Truncate(muts.Len() - 1)
+					}
+					return muts.String()
+				}(),
+				func() string {
+					var fss bytes.Buffer
+					for _, fs := range r.FrameShifts {
+						fss.WriteString(fs.ToString())
+						fss.WriteString(",")
+					}
+					if fss.Len() > 0 {
+						fss.Truncate(fss.Len() - 1)
+					}
+					return fss.String()
+				}(),
+			))
+		}
+		file.WriteString("\n")
+	}
+}
+
+func WriteJSON(
+	file *os.File, textGenes []string,
+	seqs []fastareader.Sequence, resultMap map[string][]AlignmentResult) {
+
+	finalResultMap := make(map[string][]AlignmentResult)
+	genesCount := len(textGenes)
+
+	for i := 0; i < genesCount; i++ {
+		textGene := textGenes[i]
+		for _, seq := range seqs {
+			seqResult := resultMap[seq.Name]
+			if seqResult != nil {
+				seqGeneResult := seqResult[i]
+				finalResultMap[textGene] = append(finalResultMap[textGene], seqGeneResult)
+			}
+		}
+	}
+	result, err := json.MarshalIndent(finalResultMap, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	file.Write(result)
+}
+
+func SeqSlice2Chan(s []fastareader.Sequence, bufferSize int) chan fastareader.Sequence {
+	c := make(chan fastareader.Sequence, bufferSize)
+	go func() {
+		for _, item := range s {
+			c <- item
+		}
+		close(c)
+	}()
+	return c
+}

--- a/cli/hiv1b/hiv1b.go
+++ b/cli/hiv1b/hiv1b.go
@@ -1,20 +1,11 @@
 package hiv1b
 
 import (
-	"fmt"
-	"github.com/hivdb/nucamino/alignment"
 	cli "github.com/hivdb/nucamino/cli/cli"
-	d "github.com/hivdb/nucamino/data"
-	h "github.com/hivdb/nucamino/scorehandler/general"
-	a "github.com/hivdb/nucamino/types/amino"
-	"github.com/hivdb/nucamino/utils/fastareader"
-	"log"
-	"os"
-	"runtime"
-	"sync"
+	data "github.com/hivdb/nucamino/data"
 )
 
-var AllPositionalIndelScores = map[cli.Gene]map[int][2]int{
+var hiv1bPositionalIndelScores = cli.PositionalIndelScores{
 	cli.GAG: map[int][2]int{
 		111: [2]int{-5, 0},
 		112: [2]int{-5, 0},
@@ -180,129 +171,21 @@ var AllPositionalIndelScores = map[cli.Gene]map[int][2]int{
 	},
 }
 
-
 func PerformAlignment(
-	inputFileName string,
-	outputFileName string,
+	ioParams cli.IOParameters,
 	textGenes []string,
-	indelCodonOpeningBonus int,
-	indelCodonExtensionBonus int,
-	stopCodonPenalty int,
-	gapOpeningPenalty int,
-	gapExtensionPenalty int,
 	goroutines int,
-	outputFormat string, quiet bool) {
+	quiet bool,
+	alignmentParams cli.AlignmentParameters) {
 
-	runtime.LockOSThread()
-	numCPU := runtime.NumCPU()
-	logger := log.New(os.Stderr, "", 0)
-	if goroutines == 0 {
-		goroutines = numCPU
-	}
-	if !quiet {
-		logger.Printf(
-			"%d CPUs were detected. %d goroutines will be created.\n",
-			numCPU, goroutines)
-	}
-
-	var input, output *os.File
-	var err error
-	if inputFileName == "-" {
-		input = os.Stdin
-	} else {
-		input, err = os.Open(inputFileName)
-		if err != nil {
-			logger.Fatal(err)
-			return
-		}
-	}
-	if outputFileName == "-" {
-		output = os.Stdout
-	} else {
-		output, err = os.Create(outputFileName)
-		if err != nil {
-			logger.Fatal(err)
-			return
-		}
-	}
-
-	genesCount := len(textGenes)
-	genes := make([]cli.Gene, genesCount)
-	refs := make([][]a.AminoAcid, genesCount)
-	for i, textGene := range textGenes {
-		genes[i] = cli.GeneLookup[textGene]
-		refs[i] = d.HIV1BRefLookup[textGene]
-	}
-
-	var (
-		wg         = sync.WaitGroup{}
-		seqs       = fastareader.ReadSequences(input)
-		resultChan = make(chan []cli.AlignmentResult)
-		resultMap  = make(map[string][]cli.AlignmentResult)
-	)
-	if !quiet {
-		logger.Printf("%d sequences were found from the input file.\n", len(seqs))
-	}
-	var seqChan = cli.SeqSlice2Chan(seqs, goroutines*4)
-	for i := 0; i < goroutines; i++ {
-		wg.Add(1)
-		go func(idx int, rChan chan<- []cli.AlignmentResult) {
-			scoreHandlers := make([]*h.GeneralScoreHandler, genesCount)
-			for i, gene := range genes {
-				positionalIndelScores, isPositionalIndelScoreSupported := AllPositionalIndelScores[gene]
-				scoreHandlers[i] = h.New(
-					stopCodonPenalty,
-					gapOpeningPenalty,
-					gapExtensionPenalty,
-					indelCodonOpeningBonus,
-					indelCodonExtensionBonus,
-					positionalIndelScores,
-					isPositionalIndelScoreSupported)
-			}
-			for seq := range seqChan {
-				isSimpleAlignment := true
-				result := make([]cli.AlignmentResult, genesCount)
-				for i := 0; i < genesCount; i++ {
-					aligned, err := alignment.NewAlignment(seq.Sequence, refs[i], scoreHandlers[i])
-					if err != nil {
-						result[i] = cli.AlignmentResult{seq.Name, nil, err.Error(), err}
-					} else {
-						r := aligned.GetReport()
-						result[i] = cli.AlignmentResult{seq.Name, r, "", nil}
-						isSimpleAlignment = isSimpleAlignment && r.IsSimpleAlignment
-					}
-				}
-				rChan <- result
-				if !quiet {
-					if isSimpleAlignment {
-						fmt.Fprintf(os.Stderr, ":")
-					} else {
-						fmt.Fprintf(os.Stderr, ".")
-					}
-				}
-			}
-			wg.Done()
-		}(i, resultChan)
-	}
-	go func(rChan chan<- []cli.AlignmentResult) {
-		wg.Wait()
-		if !quiet {
-			logger.Printf("\n")
-		}
-		close(rChan)
-	}(resultChan)
-	for result := range resultChan {
-		resultMap[result[0].Name] = result
-	}
-	switch outputFormat {
-	case "tsv":
-		cli.WriteTSV(output, textGenes, seqs, resultMap)
-		break
-	case "json":
-		cli.WriteJSON(output, textGenes, seqs, resultMap)
-		break
-	}
-	if !quiet && outputFileName != "-" {
-		logger.Printf("Created alignment result file %s.", outputFileName)
-	}
+	cli.PerformAlignment(
+		ioParams.InputFileName,
+		ioParams.OutputFileName,
+		ioParams.OutputFormat,
+		textGenes,
+		goroutines,
+		quiet,
+		alignmentParams,
+		hiv1bPositionalIndelScores,
+		data.HIV1BRefLookup)
 }

--- a/cmd/nucamino/hiv1b.go
+++ b/cmd/nucamino/hiv1b.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	cli "github.com/hivdb/nucamino/cli/cli"
 	hiv1bcli "github.com/hivdb/nucamino/cli/hiv1b"
 	"github.com/pkg/profile"
 )
@@ -25,12 +26,24 @@ func (self *HIV1BOptions) Execute(args []string) error {
 	if self.Pprof.Pprof {
 		defer profile.Start(profile.CPUProfile).Stop()
 	}
-	hiv1bcli.PerformAlignment(
-		string(self.Files.Input), string(self.Files.Output), self.Genes,
-		self.IndelCodonOpeningBonus, self.IndelCodonExtensionBonus,
-		self.StopCodonPenalty, self.GapOpeningPenalty,
-		self.GapExtensionPenalty, self.Goroutines,
-		self.OutputFormat, self.Quiet)
+
+	ioParams := cli.IOParameters{
+		InputFileName:  string(self.Files.Input),
+		OutputFileName: string(self.Files.Output),
+		OutputFormat:   self.OutputFormat,
+	}
+
+	alignmentParams := cli.AlignmentParameters{
+		IndelCodonOpeningBonus:   self.IndelCodonOpeningBonus,
+		IndelCodonExtensionBonus: self.IndelCodonExtensionBonus,
+		StopCodonPenalty:         self.StopCodonPenalty,
+		GapOpeningPenalty:        self.GapOpeningPenalty,
+		GapExtensionPenalty:      self.GapExtensionPenalty,
+	}
+
+	hiv1bcli.PerformAlignment(ioParams, self.Genes, self.Goroutines,
+		self.Quiet, alignmentParams)
+
 	return nil
 }
 

--- a/data/common.go
+++ b/data/common.go
@@ -1,0 +1,7 @@
+package data
+
+import a "github.com/hivdb/nucamino/types/amino"
+
+// A map of gene names to arrays of amino acids, for storing the
+// reference sequences of genes of interest.
+type SequenceMap map[string][]a.AminoAcid

--- a/data/hiv1b.go
+++ b/data/hiv1b.go
@@ -39,7 +39,7 @@ var (
 	`) // 345 AAs
 )
 
-var HIV1BRefLookup = map[string][]a.AminoAcid{
+var HIV1BRefLookup = SequenceMap{
 	"GAG":  HIV1BSEQ_GAG,
 	"POL":  HIV1BSEQ_POL,
 	"GP41": HIV1BSEQ_GP41,


### PR DESCRIPTION
These commits factor HIV1B specific code in the CLI package into a separate package. This is almost 100% moving code around, with a few new data types to make passing information from the genome-specific alignment procedure into the generic alignment procedure less verbose.