### PR TITLE
Print and Read AlignmentProfiles

### DIFF
--- a/alignmentprofile/builtin/hcv1a/hcv1a.go
+++ b/alignmentprofile/builtin/hcv1a/hcv1a.go
@@ -1,9 +1,8 @@
 package hcv1a
 
 import (
-	a "github.com/hivdb/nucamino/types/amino"
 	ap "github.com/hivdb/nucamino/alignmentprofile"
-	cli "github.com/hivdb/nucamino/cli"
+	a "github.com/hivdb/nucamino/types/amino"
 )
 
 var hcv1aPositionalIndelScores = ap.GenePositionalIndelScores{}
@@ -44,15 +43,13 @@ var (
 	`)
 )
 
-var HCV1ARefLookup = ap.ReferenceSeqs {
-	"NS3": HCV1ASEQ_NS3,
+var HCV1ARefLookup = ap.ReferenceSeqs{
+	"NS3":  HCV1ASEQ_NS3,
 	"NS5A": HCV1ASEQ_NS5A,
 	"NS5B": HCV1ASEQ_NS5B,
 }
 
-
-
-var alignmentProfile = ap.AlignmentProfile{
+var Profile = ap.AlignmentProfile{
 	StopCodonPenalty:         4,
 	GapOpeningPenalty:        10,
 	GapExtensionPenalty:      2,
@@ -60,20 +57,4 @@ var alignmentProfile = ap.AlignmentProfile{
 	IndelCodonExtensionBonus: 2,
 	GeneIndelScores:          hcv1aPositionalIndelScores,
 	ReferenceSequences:       HCV1ARefLookup,
-}
-
-func PerformAlignment(
-	ioParams cli.IOParameters,
-	cmdGenes []string,
-	goroutines int,
-	quiet bool) {
-
-	cli.PerformAlignment(
-		ioParams.InputFileName,
-		ioParams.OutputFileName,
-		ioParams.OutputFormat,
-		cmdGenes,
-		goroutines,
-		quiet,
-		alignmentProfile)
 }

--- a/alignmentprofile/builtin/hiv1b/hiv1b.go
+++ b/alignmentprofile/builtin/hiv1b/hiv1b.go
@@ -2,7 +2,6 @@ package hiv1b
 
 import (
 	ap "github.com/hivdb/nucamino/alignmentprofile"
-	cli "github.com/hivdb/nucamino/cli"
 	a "github.com/hivdb/nucamino/types/amino"
 )
 
@@ -216,7 +215,7 @@ var HIV1BRefLookup = ap.ReferenceSeqs{
 	"GP41": HIV1BSEQ_GP41,
 }
 
-var alignmentProfile = ap.AlignmentProfile{
+var Profile = ap.AlignmentProfile{
 	StopCodonPenalty:         4,
 	GapOpeningPenalty:        10,
 	GapExtensionPenalty:      2,
@@ -224,20 +223,4 @@ var alignmentProfile = ap.AlignmentProfile{
 	IndelCodonExtensionBonus: 2,
 	GeneIndelScores:          hiv1bPositionalIndelScores,
 	ReferenceSequences:       HIV1BRefLookup,
-}
-
-func PerformAlignment(
-	ioParams cli.IOParameters,
-	textGenes []string,
-	goroutines int,
-	quiet bool) {
-
-	cli.PerformAlignment(
-		ioParams.InputFileName,
-		ioParams.OutputFileName,
-		ioParams.OutputFormat,
-		textGenes,
-		goroutines,
-		quiet,
-		alignmentProfile)
 }

--- a/alignmentprofile/format.go
+++ b/alignmentprofile/format.go
@@ -19,7 +19,7 @@ ReferenceSequences:
 {{ range $gene, $seq := .ReferenceSequences }}  {{$gene}}:
     {{$seq}}
 {{end -}}
-PositionalIndelScores:
+{{ if .RawIndelScores -}} PositionalIndelScores: {{- end }}
 {{range $gene, $rawIndels := .RawIndelScores}}  {{$gene}}:
 {{- range $rawIndels}}
     - [ {{.Kind}}, {{.Position}}, {{.Open}}, {{.Extend}} ]

--- a/alignmentprofile/format.go
+++ b/alignmentprofile/format.go
@@ -1,0 +1,44 @@
+package alignmentprofile
+
+// This package contains procedures for serializing
+// rawAlignmentProfile structs. It uses the built-in template package
+// instead of YAML serialization because it needs tighter control of
+// the resulting data's formatting than our YAML parser has.
+
+import (
+	"bytes"
+	"text/template"
+)
+
+var profileTemplateSrc = `StopCodonPenalty: {{.StopCodonPenalty}}
+GapOpeningPenalty: {{.GapOpeningPenalty}}
+GapExtensionPenalty: {{.GapExtensionPenalty}}
+IndelCodonOpeningBonus: {{.IndelCodonOpeningBonus}}
+IndelCodonExtensionBonus: {{.IndelCodonExtensionBonus}}
+ReferenceSequences:
+{{ range $gene, $seq := .ReferenceSequences }}  {{$gene}}:
+    {{$seq}}
+{{end -}}
+PositionalIndelScores:
+{{range $gene, $rawIndels := .RawIndelScores}}  {{$gene}}:
+{{- range $rawIndels}}
+    - [ {{.Kind}}, {{.Position}}, {{.Open}}, {{.Extend}} ]
+{{- end}}
+{{end}}`
+
+var profileTemplate *template.Template
+
+func init() {
+	profileTemplate = template.Must(template.New("alignmentprofile").Parse(profileTemplateSrc))
+
+}
+
+func Format(ap AlignmentProfile) string {
+	rawProfile := ap.asRaw()
+	var buff bytes.Buffer
+	err := profileTemplate.Execute(&buff, rawProfile)
+	if err != nil {
+		panic(err)
+	}
+	return buff.String()
+}

--- a/alignmentprofile/format.go
+++ b/alignmentprofile/format.go
@@ -30,7 +30,6 @@ var profileTemplate *template.Template
 
 func init() {
 	profileTemplate = template.Must(template.New("alignmentprofile").Parse(profileTemplateSrc))
-
 }
 
 func Format(ap AlignmentProfile) string {

--- a/alignmentprofile/formatparse_test.go
+++ b/alignmentprofile/formatparse_test.go
@@ -1,10 +1,9 @@
 package alignmentprofile
 
 import (
-	"testing"
 	"reflect"
+	"testing"
 )
-
 
 func TestFormatParseRoundTrip(t *testing.T) {
 	formatted := Format(exampleProfile)
@@ -18,7 +17,7 @@ func TestFormatParseRoundTrip(t *testing.T) {
 	}
 }
 
-var exampleProfileYAML =`StopCodonPenalty: 1
+var exampleProfileYAML = `StopCodonPenalty: 1
 GapOpeningPenalty: 2
 GapExtensionPenalty: 3
 IndelCodonOpeningBonus: 4

--- a/alignmentprofile/formatparse_test.go
+++ b/alignmentprofile/formatparse_test.go
@@ -1,0 +1,51 @@
+package alignmentprofile
+
+import (
+	"testing"
+	"reflect"
+)
+
+
+func TestFormatParseRoundTrip(t *testing.T) {
+	formatted := Format(exampleProfile)
+	parsed, err := Parse(formatted)
+	if err != nil {
+		t.Errorf("Unexpected error while parsing formatted profile: %v", err)
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(*parsed, exampleProfile) {
+		t.Errorf("%v != %v", *parsed, exampleProfile)
+	}
+}
+
+var exampleProfileYAML =`StopCodonPenalty: 1
+GapOpeningPenalty: 2
+GapExtensionPenalty: 3
+IndelCodonOpeningBonus: 4
+IndelCodonExtensionBonus: 5
+ReferenceSequences:
+  A:
+    TTALIEPPVYPIVEHSDEKTAHEEH
+  B:
+    CSNELVISHEADPVWRSAVLRGAP
+PositionalIndelScores:
+  A:
+    - [ ins, 3, 4, 5 ]
+    - [ ins, 6, 7, 8 ]
+    - [ del, 6, 7, 8 ]
+    - [ del, 9, 10, 11 ]
+  B:
+    - [ ins, 2, 1, 2 ]
+`
+
+func TestParseFormatRoundTrip(t *testing.T) {
+	parsed, err := Parse(exampleProfileYAML)
+	if err != nil {
+		t.Errorf("Unexpected error while parsing example YAML: %v", err)
+		t.FailNow()
+	}
+	formatted := Format(*parsed)
+	if formatted != exampleProfileYAML {
+		t.Errorf("%v != %v", formatted, exampleProfileYAML)
+	}
+}

--- a/alignmentprofile/parse.go
+++ b/alignmentprofile/parse.go
@@ -25,5 +25,9 @@ func Parse(src string) (*AlignmentProfile, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = profile.validate()
+	if err != nil {
+		return nil, err
+	}
 	return &profile, nil
 }

--- a/alignmentprofile/parse.go
+++ b/alignmentprofile/parse.go
@@ -1,0 +1,29 @@
+package alignmentprofile
+
+import (
+	yaml "gopkg.in/yaml.v2"
+)
+
+func (p *AlignmentProfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw rawAlignmentProfile
+	err := unmarshal(&raw)
+	if err != nil {
+		return err
+	}
+	profile, err := raw.asProfile()
+	if err != nil {
+		return err
+	}
+	*p = *profile
+	return nil
+}
+
+// Parse an AlignmentProfile from YAML
+func Parse(src string) (*AlignmentProfile, error) {
+	var profile AlignmentProfile
+	err := yaml.Unmarshal([]byte(src), &profile)
+	if err != nil {
+		return nil, err
+	}
+	return &profile, nil
+}

--- a/alignmentprofile/parse_test.go
+++ b/alignmentprofile/parse_test.go
@@ -1,0 +1,23 @@
+package alignmentprofile
+
+import "testing"
+
+func TestUnmarshalEmpty(t *testing.T) {
+	src := ""
+	_, err := Parse(src)
+	if err == nil {
+		t.Errorf("Expected error on empty YAML file")
+	}
+}
+
+func TestInvalidProfile(t *testing.T) {
+	src := `StopCodonPenalty: 0
+GapOpeningPenalty: 0
+GapExtensionPenalty: 0
+IndelCodonOpeningBonus: 0
+IndelCodonExtensionBonus: 0`
+	_, err := Parse(src)
+	if err == nil {
+		t.Errorf("Expected error when missing ReferenceSequences")
+	}
+}

--- a/alignmentprofile/profile.go
+++ b/alignmentprofile/profile.go
@@ -30,3 +30,33 @@ func (profile AlignmentProfile) Genes() []Gene {
 	}
 	return genes
 }
+
+func (profile AlignmentProfile) rawIndelScores() map[string][]rawIndelScore {
+	result := make(map[string][]rawIndelScore)
+	for gene, positionalIndelScores := range profile.GeneIndelScores {
+		rawIndelScores := make([]rawIndelScore, 0, len(positionalIndelScores))
+		for posKey, scores := range positionalIndelScores {
+			var pos int
+			var kind string
+			// Interpret the position key in the positional indel
+			// scores map: the magnitude is the position, negative
+			// indicates deletion.
+			if posKey >= 0 {
+				pos = posKey
+				kind = "ins"
+			} else {
+				pos = -posKey
+				kind = "del"
+			}
+			rawScore := rawIndelScore{
+				Kind:     kind,
+				Position: pos,
+				Open:     scores[0],
+				Extend:   scores[1],
+			}
+			rawIndelScores = append(rawIndelScores, rawScore)
+		}
+		result[string(gene)] = rawIndelScores
+	}
+	return result
+}

--- a/alignmentprofile/profile.go
+++ b/alignmentprofile/profile.go
@@ -1,3 +1,6 @@
+// This package contains data structures that hold all the information
+// required by the alignment algorithm, and procedures for serializing
+// and deserializing that information.
 package alignmentprofile
 
 import (

--- a/alignmentprofile/profile.go
+++ b/alignmentprofile/profile.go
@@ -2,6 +2,7 @@ package alignmentprofile
 
 import (
 	a "github.com/hivdb/nucamino/types/amino"
+	"sort"
 )
 
 type Gene string
@@ -56,6 +57,7 @@ func (profile AlignmentProfile) rawIndelScores() map[string][]rawIndelScore {
 			}
 			rawIndelScores = append(rawIndelScores, rawScore)
 		}
+		sort.Sort(byPositionAndKind(rawIndelScores))
 		result[string(gene)] = rawIndelScores
 	}
 	return result

--- a/alignmentprofile/profile.go
+++ b/alignmentprofile/profile.go
@@ -84,3 +84,9 @@ func (profile AlignmentProfile) asRaw() rawAlignmentProfile {
 	}
 	return raw
 }
+
+// Retrieve the positional indel scores for a Gene.
+func (profile *AlignmentProfile) PositionalIndelScoresFor(g Gene) (PositionalIndelScores, bool) {
+	scores, found := profile.GeneIndelScores[g]
+	return scores, found
+}

--- a/alignmentprofile/profile.go
+++ b/alignmentprofile/profile.go
@@ -9,9 +9,9 @@ type PositionalIndelScores map[int]([2]int)
 type GenePositionalIndelScores map[Gene]PositionalIndelScores
 type ReferenceSeqs map[Gene][]a.AminoAcid
 
-// This stores the all the information needed to align a sequence
-// against a particular reference: alignment parameters, positional
-// in-del scores, and the reference sequences to be aligned against.
+// This stores the all the information needed to align a sequence to a
+// reference: reference sequences, alignment parameters, and
+// positional indel scores.
 type AlignmentProfile struct {
 	StopCodonPenalty         int
 	GapOpeningPenalty        int
@@ -20,26 +20,6 @@ type AlignmentProfile struct {
 	IndelCodonExtensionBonus int
 	GeneIndelScores          GenePositionalIndelScores
 	ReferenceSequences       ReferenceSeqs
-}
-
-func (profile *AlignmentProfile) SupportsPositionalIndelScores() bool {
-	return profile.GeneIndelScores != nil
-}
-
-func (profile *AlignmentProfile) SupportsPositionalIndelScoresFor(gene Gene) bool {
-	if !profile.SupportsPositionalIndelScores() {
-		return false
-	}
-	_, hasKey := profile.GeneIndelScores[gene]
-	return hasKey
-}
-
-func (profile *AlignmentProfile) PositionalIndelScoresFor(g Gene) (PositionalIndelScores, bool) {
-	if !profile.SupportsPositionalIndelScores() {
-		return nil, false
-	}
-	scores, found := profile.GeneIndelScores[g]
-	return scores, found
 }
 
 // An array of all the genes supported by this alignment profile.

--- a/alignmentprofile/profile.go
+++ b/alignmentprofile/profile.go
@@ -23,7 +23,7 @@ type AlignmentProfile struct {
 }
 
 // An array of all the genes supported by this alignment profile.
-func (profile *AlignmentProfile) Genes() []Gene {
+func (profile AlignmentProfile) Genes() []Gene {
 	var genes = make([]Gene, 0, len(profile.ReferenceSequences))
 	for gene, _ := range profile.ReferenceSequences {
 		genes = append(genes, gene)

--- a/alignmentprofile/profile.go
+++ b/alignmentprofile/profile.go
@@ -4,6 +4,7 @@
 package alignmentprofile
 
 import (
+	"fmt"
 	a "github.com/hivdb/nucamino/types/amino"
 	"sort"
 )
@@ -89,4 +90,13 @@ func (profile AlignmentProfile) asRaw() rawAlignmentProfile {
 func (profile *AlignmentProfile) PositionalIndelScoresFor(g Gene) (PositionalIndelScores, bool) {
 	scores, found := profile.GeneIndelScores[g]
 	return scores, found
+}
+
+
+// Check that the profile isn't empty
+func (profile AlignmentProfile) validate() error {
+	if len(profile.ReferenceSequences) == 0 {
+		return fmt.Errorf("Missing key: ReferenceSequence")
+	}
+	return nil
 }

--- a/alignmentprofile/profile.go
+++ b/alignmentprofile/profile.go
@@ -62,3 +62,22 @@ func (profile AlignmentProfile) rawIndelScores() map[string][]rawIndelScore {
 	}
 	return result
 }
+
+func (profile AlignmentProfile) asRaw() rawAlignmentProfile {
+	var raw rawAlignmentProfile
+	raw.StopCodonPenalty = profile.StopCodonPenalty
+	raw.GapOpeningPenalty = profile.GapOpeningPenalty
+	raw.GapExtensionPenalty = profile.GapExtensionPenalty
+	raw.IndelCodonOpeningBonus = profile.IndelCodonOpeningBonus
+	raw.IndelCodonExtensionBonus = profile.IndelCodonExtensionBonus
+
+	raw.ReferenceSequences = make(map[string]string)
+	for gene, aaSeq := range profile.ReferenceSequences {
+		raw.ReferenceSequences[string(gene)] = a.WriteString(aaSeq)
+	}
+
+	if profile.GeneIndelScores != nil {
+		raw.RawIndelScores = profile.rawIndelScores()
+	}
+	return raw
+}

--- a/alignmentprofile/profile_test.go
+++ b/alignmentprofile/profile_test.go
@@ -24,7 +24,7 @@ var exampleProfile = AlignmentProfile{
 			-9: [2]int{10, 11},
 		},
 		Gene("B"): PositionalIndelScores{
-			2:  [2]int{1, 2},
+			2: [2]int{1, 2},
 		},
 	},
 }

--- a/alignmentprofile/profile_test.go
+++ b/alignmentprofile/profile_test.go
@@ -12,19 +12,6 @@ var exampleProfile = AlignmentProfile{
 	},
 }
 
-var exampleProfileWithPositionalIndelScores = AlignmentProfile{
-	ReferenceSequences: ReferenceSeqs{
-		"A": a.ReadString("T"),
-		"B": a.ReadString("V"),
-	},
-	GeneIndelScores: GenePositionalIndelScores{
-		"A": PositionalIndelScores{
-			0: [2]int{1, 2},
-			1: [2]int{3, 4},
-		},
-	},
-}
-
 func TestGenes(t *testing.T) {
 	genes := exampleProfile.Genes()
 	expected := [2]Gene{"A", "B"}
@@ -45,26 +32,4 @@ func TestGenes(t *testing.T) {
 		}
 	}
 
-}
-
-func TestPositionalIndelScoreSupportChecking(t *testing.T) {
-	if exampleProfile.SupportsPositionalIndelScores() {
-		t.Errorf("This example profile doens't have positional indel scores")
-	}
-	if !exampleProfileWithPositionalIndelScores.SupportsPositionalIndelScores() {
-		t.Errorf("This example profile does have positional indel scores")
-	}
-}
-
-func TestPositionalIndelScoresByGene(t *testing.T) {
-	p := exampleProfileWithPositionalIndelScores
-	if !p.SupportsPositionalIndelScoresFor("A") {
-		t.Errorf("Expected this profile to have scores for 'A'")
-	}
-	if p.SupportsPositionalIndelScoresFor("B") {
-		t.Errorf("Expected no scores for 'B'")
-	}
-	if exampleProfile.SupportsPositionalIndelScoresFor("A") {
-		t.Errorf("Expected no support from this profile")
-	}
 }

--- a/alignmentprofile/profile_test.go
+++ b/alignmentprofile/profile_test.go
@@ -79,3 +79,14 @@ func TestRoundTripToRawProfile(t *testing.T) {
 		t.Errorf("%v != %v", *constructed, exampleProfile)
 	}
 }
+
+func TestRetrievingPositionalIndelScores(t *testing.T) {
+	_, found := exampleProfile.PositionalIndelScoresFor("A")
+	if !found {
+		t.Errorf("Failed to retrieve positional indel scores in example profile")
+	}
+	_, found = exampleProfile.PositionalIndelScoresFor("Z")
+	if found {
+		t.Errorf("Found positional indel scores for non-existent gene in example profile")
+	}
+}

--- a/alignmentprofile/profile_test.go
+++ b/alignmentprofile/profile_test.go
@@ -2,6 +2,7 @@ package alignmentprofile
 
 import (
 	a "github.com/hivdb/nucamino/types/amino"
+	"reflect"
 	"testing"
 )
 
@@ -43,5 +44,20 @@ func TestGenes(t *testing.T) {
 		if !found {
 			t.Errorf("Missing key: %v", exp)
 		}
+	}
+}
+
+func TestRawIndelScoresFromProfile(t *testing.T) {
+	expected := map[string][]rawIndelScore{
+		"A": []rawIndelScore{
+			{Kind: "ins", Position: 3, Open: 4, Extend: 5},
+			{Kind: "ins", Position: 6, Open: 7, Extend: 8},
+			{Kind: "del", Position: 6, Open: 7, Extend: 8},
+			{Kind: "del", Position: 9, Open: 10, Extend: 11},
+		},
+	}
+	constructed := exampleProfile.rawIndelScores()
+	if !reflect.DeepEqual(constructed, expected) {
+		t.Errorf("%v != %v", constructed, expected)
 	}
 }

--- a/alignmentprofile/profile_test.go
+++ b/alignmentprofile/profile_test.go
@@ -13,8 +13,8 @@ var exampleProfile = AlignmentProfile{
 	IndelCodonOpeningBonus:   4,
 	IndelCodonExtensionBonus: 5,
 	ReferenceSequences: ReferenceSeqs{
-		"A": a.ReadString("T"),
-		"B": a.ReadString("V"),
+		"A": a.ReadString("TTALIEPPVYPIVEHSDEKTAHEEH"),
+		"B": a.ReadString("CSNELVISHEADPVWRSAVLRGAP"),
 	},
 	GeneIndelScores: GenePositionalIndelScores{
 		Gene("A"): PositionalIndelScores{
@@ -22,6 +22,9 @@ var exampleProfile = AlignmentProfile{
 			6:  [2]int{7, 8},
 			-6: [2]int{7, 8},
 			-9: [2]int{10, 11},
+		},
+		Gene("B"): PositionalIndelScores{
+			2:  [2]int{1, 2},
 		},
 	},
 }
@@ -54,6 +57,9 @@ func TestRawIndelScoresFromProfile(t *testing.T) {
 			{Kind: "ins", Position: 6, Open: 7, Extend: 8},
 			{Kind: "del", Position: 6, Open: 7, Extend: 8},
 			{Kind: "del", Position: 9, Open: 10, Extend: 11},
+		},
+		"B": []rawIndelScore{
+			{Kind: "ins", Position: 2, Open: 1, Extend: 2},
 		},
 	}
 	constructed := exampleProfile.rawIndelScores()

--- a/alignmentprofile/profile_test.go
+++ b/alignmentprofile/profile_test.go
@@ -6,9 +6,22 @@ import (
 )
 
 var exampleProfile = AlignmentProfile{
+	StopCodonPenalty:         1,
+	GapOpeningPenalty:        2,
+	GapExtensionPenalty:      3,
+	IndelCodonOpeningBonus:   4,
+	IndelCodonExtensionBonus: 5,
 	ReferenceSequences: ReferenceSeqs{
 		"A": a.ReadString("T"),
 		"B": a.ReadString("V"),
+	},
+	GeneIndelScores: GenePositionalIndelScores{
+		Gene("A"): PositionalIndelScores{
+			3:  [2]int{4, 5},
+			6:  [2]int{7, 8},
+			-6: [2]int{7, 8},
+			-9: [2]int{10, 11},
+		},
 	},
 }
 
@@ -31,5 +44,4 @@ func TestGenes(t *testing.T) {
 			t.Errorf("Missing key: %v", exp)
 		}
 	}
-
 }

--- a/alignmentprofile/profile_test.go
+++ b/alignmentprofile/profile_test.go
@@ -61,3 +61,15 @@ func TestRawIndelScoresFromProfile(t *testing.T) {
 		t.Errorf("%v != %v", constructed, expected)
 	}
 }
+
+func TestRoundTripToRawProfile(t *testing.T) {
+	raw := exampleProfile.asRaw()
+	constructed, err := raw.asProfile()
+	if err != nil {
+		t.Errorf("Unexpected error while converting profile to raw profile: %v", err)
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(*constructed, exampleProfile) {
+		t.Errorf("%v != %v", *constructed, exampleProfile)
+	}
+}

--- a/alignmentprofile/raw.go
+++ b/alignmentprofile/raw.go
@@ -26,6 +26,28 @@ func (t *rawIndelScore) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// This type alias lets us implement the sorting interface for
+// []rawIndelScore. We sort it first by position (with lower positions
+// first) and then by kind (with insertions before deletions).
+type byPositionAndKind []rawIndelScore
+
+func (a byPositionAndKind) Len() int {
+	return len(a)
+}
+
+func (a byPositionAndKind) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a byPositionAndKind) Less(i, j int) bool {
+	if a[i].Position < a[j].Position {
+		return true
+	} else if a[i].Position == a[j].Position {
+		return a[i].Kind == "ins" && a[j].Kind == "del"
+	}
+	return false
+}
+
 // This is an intermediate datatype between an AlignmentProfile and
 // the YAML that represents it. The YAML is formatted for editing,
 // while the AlignmentProfile is formatted for ease of

--- a/alignmentprofile/raw.go
+++ b/alignmentprofile/raw.go
@@ -1,0 +1,39 @@
+package alignmentprofile
+
+// This structure is a de-serialization target that the YAML package
+// uses to parse the GeneIndelScores in a serialized profile.
+type rawIndelScore struct {
+	Kind     string
+	Position int
+	Open     int
+	Extend   int
+}
+
+func (t *rawIndelScore) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	bucket := make([]interface{}, 4)
+	e := unmarshal(&bucket)
+	t.Kind = bucket[0].(string)
+	t.Position = bucket[1].(int)
+	t.Open = bucket[2].(int)
+	t.Extend = bucket[3].(int)
+	if e != nil {
+		return e
+	}
+	return nil
+}
+
+// This is an intermediate datatype between an AlignmentProfile and
+// the YAML that represents it. The YAML is formatted for editing,
+// while the AlignmentProfile is formatted for ease of
+// calculation. This structure can be deserialized form YAML,
+// converted to an AlignmentProfile, or contructed from an
+// AlignmentProfile.
+type rawAlignmentProfile struct {
+	StopCodonPenalty         int                        `yaml:"StopCodonPenalty"`
+	GapOpeningPenalty        int                        `yaml:"GapOpeningPenalty"`
+	GapExtensionPenalty      int                        `yaml:"GapExtensionPenalty"`
+	IndelCodonOpeningBonus   int                        `yaml:"IndelCodonOpeningBonus"`
+	IndelCodonExtensionBonus int                        `yaml:"IndelCodonExtensionBonus"`
+	GeneIndelScores          map[string][]rawIndelScore `yaml:"GeneIndelScore,flow"`
+	ReferenceSequences       map[string]string          `yaml:"ReferenceSequences"`
+}

--- a/alignmentprofile/raw.go
+++ b/alignmentprofile/raw.go
@@ -1,5 +1,12 @@
 package alignmentprofile
 
+// This file contains an intermediate representation of
+// AlignmentProfile that's used during serialization and
+// de-serialization. The serialization format is easier to read and
+// write by hand; the AlignmentProfile structure is more suitable for
+// calculation; the rawAlignmentProfile is both easy to
+// serialize/deserialize and easy to convert into an AlignmentProfile.
+
 import (
 	"fmt"
 	a "github.com/hivdb/nucamino/types/amino"

--- a/alignmentprofile/raw.go
+++ b/alignmentprofile/raw.go
@@ -68,7 +68,7 @@ type rawAlignmentProfile struct {
 	GapExtensionPenalty      int                        `yaml:"GapExtensionPenalty"`
 	IndelCodonOpeningBonus   int                        `yaml:"IndelCodonOpeningBonus"`
 	IndelCodonExtensionBonus int                        `yaml:"IndelCodonExtensionBonus"`
-	RawIndelScores           map[string][]rawIndelScore `yaml:"GeneIndelScores,flow"`
+	RawIndelScores           map[string][]rawIndelScore `yaml:"PositionalIndelScores,flow"`
 	ReferenceSequences       map[string]string          `yaml:"ReferenceSequences"`
 }
 

--- a/alignmentprofile/raw.go
+++ b/alignmentprofile/raw.go
@@ -38,7 +38,7 @@ type rawAlignmentProfile struct {
 	GapExtensionPenalty      int                        `yaml:"GapExtensionPenalty"`
 	IndelCodonOpeningBonus   int                        `yaml:"IndelCodonOpeningBonus"`
 	IndelCodonExtensionBonus int                        `yaml:"IndelCodonExtensionBonus"`
-	GeneIndelScores          map[string][]rawIndelScore `yaml:"GeneIndelScore,flow"`
+	RawIndelScores           map[string][]rawIndelScore `yaml:"GeneIndelScores,flow"`
 	ReferenceSequences       map[string]string          `yaml:"ReferenceSequences"`
 }
 
@@ -46,7 +46,7 @@ type rawAlignmentProfile struct {
 // rawAlignentProfile (which has presumably been parsed from YAML).
 func (rawProfile rawAlignmentProfile) geneIndelScores() (*GenePositionalIndelScores, error) {
 	geneIndelScores := make(GenePositionalIndelScores)
-	for geneSrc, rawIndelScores := range rawProfile.GeneIndelScores {
+	for geneSrc, rawIndelScores := range rawProfile.RawIndelScores {
 		indelScores := make(PositionalIndelScores)
 		for _, indelScore := range rawIndelScores {
 			var scoreKeySign int

--- a/alignmentprofile/raw_test.go
+++ b/alignmentprofile/raw_test.go
@@ -78,3 +78,41 @@ func TestGeneIndelScoresFromRawProfileWithInvalidScoreKind(t *testing.T) {
 		t.Errorf("Expected an error on indel kind 'foo'")
 	}
 }
+
+func TestRawIndelScoreSortOrder(t *testing.T) {
+	lessCases := [][]rawIndelScore{
+		{
+			{Position: 1},
+			{Position: 2},
+		},
+		{
+			{Position: 1, Kind: "ins"},
+			{Position: 1, Kind: "del"},
+		},
+		{
+			{Position: 1, Kind: "del"},
+			{Position: 2, Kind: "ins"},
+		},
+	}
+	for _, c := range lessCases {
+		if !byPositionAndKind(c).Less(0, 1) {
+			t.Errorf("Expected %v to be less than %v", c[0], c[1])
+		}
+	}
+	notLessCases := [][]rawIndelScore{
+		{
+			{Position: 2},
+			{Position: 1},
+		},
+		{
+			{Position: 1, Kind: "del"},
+			{Position: 1, Kind: "ins"},
+		},
+	}
+	for _, c := range notLessCases {
+		if byPositionAndKind(c).Less(0, 1) {
+			t.Errorf("Expected %v to be greater than %v", c[0], c[1])
+		}
+	}
+
+}

--- a/alignmentprofile/raw_test.go
+++ b/alignmentprofile/raw_test.go
@@ -25,7 +25,7 @@ func TestUnmarshalRawIndelScore(t *testing.T) {
 }
 
 var exampleRawProfile = rawAlignmentProfile{
-	GeneIndelScores: map[string][]rawIndelScore{
+	RawIndelScores: map[string][]rawIndelScore{
 		"A": []rawIndelScore{
 			rawIndelScore{
 				Kind:     "ins",
@@ -60,7 +60,7 @@ func TestGeneIndelScoresFromRawProfile(t *testing.T) {
 }
 
 var exampleInvalidRawProfile = rawAlignmentProfile{
-	GeneIndelScores: map[string][]rawIndelScore{
+	RawIndelScores: map[string][]rawIndelScore{
 		"A": []rawIndelScore{
 			rawIndelScore{
 				Kind:     "foo",

--- a/alignmentprofile/raw_test.go
+++ b/alignmentprofile/raw_test.go
@@ -1,0 +1,25 @@
+package alignmentprofile
+
+import (
+	yaml "gopkg.in/yaml.v2"
+	"reflect"
+	"testing"
+)
+
+func TestUnmarshalRawIndelScore(t *testing.T) {
+	src := []byte("[ins, 0, 1, 2]")
+	expected := rawIndelScore{
+		Kind:     "ins",
+		Position: 0,
+		Open:     1,
+		Extend:   2,
+	}
+	var constructed rawIndelScore
+	err := yaml.Unmarshal(src, &constructed)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(constructed, expected) {
+		t.Errorf("%+v != %+v", constructed, expected)
+	}
+}

--- a/alignmentprofile/raw_test.go
+++ b/alignmentprofile/raw_test.go
@@ -25,10 +25,10 @@ func TestUnmarshalRawIndelScore(t *testing.T) {
 }
 
 var exampleRawProfile = rawAlignmentProfile{
-	StopCodonPenalty: 0,
-	GapOpeningPenalty: 1,
-	GapExtensionPenalty: 2,
-	IndelCodonOpeningBonus: 3,
+	StopCodonPenalty:         0,
+	GapOpeningPenalty:        1,
+	GapExtensionPenalty:      2,
+	IndelCodonOpeningBonus:   3,
 	IndelCodonExtensionBonus: 4,
 	RawIndelScores: map[string][]rawIndelScore{
 		"A": []rawIndelScore{
@@ -46,7 +46,7 @@ var exampleRawProfile = rawAlignmentProfile{
 			},
 		},
 	},
-	ReferenceSequences: map[string]string {
+	ReferenceSequences: map[string]string{
 		"A": "SGSWLRD",
 		"B": "CPPDSDVESYSSMPPLEGEPGDPD",
 	},
@@ -123,5 +123,16 @@ func TestRawIndelScoreSortOrder(t *testing.T) {
 			t.Errorf("Expected %v to be greater than %v", c[0], c[1])
 		}
 	}
+}
 
+func TestRoundTipToAlignmentProfile(t *testing.T) {
+	profile, err := exampleRawProfile.asProfile()
+	if err != nil {
+		t.Errorf("Unexpected error while converting raw profile to profile: %v", err)
+		t.FailNow()
+	}
+	constructed := profile.asRaw()
+	if !reflect.DeepEqual(constructed, exampleRawProfile) {
+		t.Errorf("%v != %v", constructed, exampleRawProfile)
+	}
 }

--- a/alignmentprofile/raw_test.go
+++ b/alignmentprofile/raw_test.go
@@ -23,3 +23,58 @@ func TestUnmarshalRawIndelScore(t *testing.T) {
 		t.Errorf("%+v != %+v", constructed, expected)
 	}
 }
+
+var exampleRawProfile = rawAlignmentProfile{
+	GeneIndelScores: map[string][]rawIndelScore{
+		"A": []rawIndelScore{
+			rawIndelScore{
+				Kind:     "ins",
+				Position: 1,
+				Open:     2,
+				Extend:   3,
+			},
+			rawIndelScore{
+				Kind:     "del",
+				Position: 4,
+				Open:     5,
+				Extend:   6,
+			},
+		},
+	},
+}
+
+func TestGeneIndelScoresFromRawProfile(t *testing.T) {
+	constructed, err := exampleRawProfile.geneIndelScores()
+	expected := &GenePositionalIndelScores{
+		Gene("A"): PositionalIndelScores{
+			1:  [2]int{2, 3},
+			-4: [2]int{5, 6},
+		},
+	}
+	if err != nil {
+		t.Errorf("Unexpected Error: %v", err)
+	}
+	if !reflect.DeepEqual(constructed, expected) {
+		t.Errorf("%+v != %+v", constructed, expected)
+	}
+}
+
+var exampleInvalidRawProfile = rawAlignmentProfile{
+	GeneIndelScores: map[string][]rawIndelScore{
+		"A": []rawIndelScore{
+			rawIndelScore{
+				Kind:     "foo",
+				Position: 1,
+				Open:     2,
+				Extend:   3,
+			},
+		},
+	},
+}
+
+func TestGeneIndelScoresFromRawProfileWithInvalidScoreKind(t *testing.T) {
+	_, err := exampleInvalidRawProfile.geneIndelScores()
+	if err == nil {
+		t.Errorf("Expected an error on indel kind 'foo'")
+	}
+}

--- a/alignmentprofile/raw_test.go
+++ b/alignmentprofile/raw_test.go
@@ -25,6 +25,11 @@ func TestUnmarshalRawIndelScore(t *testing.T) {
 }
 
 var exampleRawProfile = rawAlignmentProfile{
+	StopCodonPenalty: 0,
+	GapOpeningPenalty: 1,
+	GapExtensionPenalty: 2,
+	IndelCodonOpeningBonus: 3,
+	IndelCodonExtensionBonus: 4,
 	RawIndelScores: map[string][]rawIndelScore{
 		"A": []rawIndelScore{
 			rawIndelScore{
@@ -40,6 +45,10 @@ var exampleRawProfile = rawAlignmentProfile{
 				Extend:   6,
 			},
 		},
+	},
+	ReferenceSequences: map[string]string {
+		"A": "SGSWLRD",
+		"B": "CPPDSDVESYSSMPPLEGEPGDPD",
 	},
 }
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -133,7 +133,6 @@ func PerformAlignment(
 	quiet bool,
 	alignmentProfile ap.AlignmentProfile) {
 
-
 	// Configure runtime
 	runtime.LockOSThread()
 	numCPU := runtime.NumCPU()

--- a/cmd/nucamino/hcv1a.go
+++ b/cmd/nucamino/hcv1a.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	hcv1a "github.com/hivdb/nucamino/alignmentprofile/builtin/hcv1a"
 	cli "github.com/hivdb/nucamino/cli"
-	hcv1acli "github.com/hivdb/nucamino/cli/hcv1a"
 	"github.com/pkg/profile"
 )
 
@@ -33,7 +33,14 @@ func (self *HCV1AOptions) Execute(args []string) error {
 		OutputFormat:   self.OutputFormat,
 	}
 
-	hcv1acli.PerformAlignment(ioParams, self.Genes, self.Goroutines, self.Quiet)
+	cli.PerformAlignment(
+		ioParams.InputFileName,
+		ioParams.OutputFileName,
+		ioParams.OutputFormat,
+		self.Genes,
+		self.Goroutines,
+		self.Quiet,
+		hcv1a.Profile)
 
 	return nil
 }

--- a/cmd/nucamino/hiv1b.go
+++ b/cmd/nucamino/hiv1b.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	hiv1b "github.com/hivdb/nucamino/alignmentprofile/builtin/hiv1b"
 	cli "github.com/hivdb/nucamino/cli"
-	hiv1bcli "github.com/hivdb/nucamino/cli/hiv1b"
 	"github.com/pkg/profile"
 )
 
@@ -33,7 +33,14 @@ func (self *HIV1BOptions) Execute(args []string) error {
 		OutputFormat:   self.OutputFormat,
 	}
 
-	hiv1bcli.PerformAlignment(ioParams, self.Genes, self.Goroutines, self.Quiet)
+	cli.PerformAlignment(
+		ioParams.InputFileName,
+		ioParams.OutputFileName,
+		ioParams.OutputFormat,
+		self.Genes,
+		self.Goroutines,
+		self.Quiet,
+		hiv1b.Profile)
 
 	return nil
 }


### PR DESCRIPTION
This commit adds two functions to the `alignmentprofile`, `Format` and `Parse`, which transform and AlignmentProfile into a YAML formatted string and a YAML formatted string into an AlignmentProfile, respectively.