### PR TITLE
Add a `list-genes` subcommand to `nucamino profile`

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,10 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	builtin "github.com/hivdb/nucamino/alignmentprofile/builtin"
+	"github.com/hivdb/nucamino/alignmentprofile/builtin"
 	"github.com/spf13/cobra"
 	"log"
-	"os"
 	"regexp"
 )
 
@@ -29,7 +28,7 @@ regular expression. For example:
 See https://github.com/google/re2/wiki/Syntax for the exact details of
 the regular expression syntax.`,
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		profileNames := builtin.List()
 		if len(args) == 1 {
 			var pattern *regexp.Regexp
@@ -37,8 +36,7 @@ the regular expression syntax.`,
 			pattern, err := regexp.Compile(patternSrc)
 			if err != nil {
 				log.Printf("Error in pattern: %v", err)
-				os.Exit(1)
-				return
+				return err
 			}
 			matchingProfileNames := make([]string, 0, len(profileNames))
 			for _, name := range profileNames {
@@ -51,6 +49,7 @@ the regular expression syntax.`,
 		for _, name := range profileNames {
 			fmt.Println(name)
 		}
+		return nil
 	},
 }
 

--- a/cmd/listGenes.go
+++ b/cmd/listGenes.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	ap "github.com/hivdb/nucamino/alignmentprofile"
+	"github.com/hivdb/nucamino/alignmentprofile/builtin"
+	"github.com/spf13/cobra"
+	"log"
+	"regexp"
+)
+
+func listGenes(cmd *cobra.Command, args []string) error {
+	profileName := args[0]
+	profile, found := builtin.Get(profileName)
+	if !found {
+		tmpl := `Unknown profile name: '%v'
+
+see 'nucamino profile list' for a list of available alignment profiles`
+		err := fmt.Errorf(tmpl, profileName)
+		return err
+	}
+	genes := profile.Genes()
+	if len(args) == 2 {
+		patternSrc := args[1]
+		pattern, err := regexp.Compile(patternSrc)
+		if err != nil {
+			log.Printf("Error in search pattern")
+			return err
+		}
+		matchingGenes := make([]ap.Gene, 0, len(genes))
+		for _, gene := range genes {
+			if pattern.MatchString(string(gene)) {
+				matchingGenes = append(matchingGenes, gene)
+			}
+		}
+		genes = matchingGenes
+	}
+	for _, gene := range(genes) {
+		fmt.Println(gene)
+	}
+	return nil
+}
+
+
+var listGenesCmd = &cobra.Command{
+	Use:   "list-genes profile [pattern]",
+	Short: "List the available genes in a built-in alignment profile",
+	Long: `This command lists the genes available  in a built-in alignment
+profile. These names could be used to construct an align command, or just
+to learn about the available options without printing out the whole profile.
+
+The pattern argument is used to filter the list. It's interpreted as a
+regular expression. For example:
+
+	nucamino profile list-genes hcv1a		List the genes in the built-in HCV1a profile.
+	nucamino profile list-genes	hiv1b ^G	List the genes in the HIV1b profile that start
+											with a 'G'.
+
+See https://github.com/google/re2/wiki/Syntax for the exact details of
+the regular expression syntax.`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: listGenes,
+}
+
+
+func init() {
+	profileCmd.AddCommand(listGenesCmd)
+}

--- a/cmd/listGenes_test.go
+++ b/cmd/listGenes_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import "testing"
+
+func TestListGenesErrorHandling(t *testing.T) {
+	var builtinProfile = "hcv1a"
+	var err error
+
+	err = listGenes(nil, []string{"not-a-profile"})
+	if err == nil {
+		t.Errorf("Expected missing gene-name to raise an error")
+	}
+
+	var invalidRegex = "a[bc"
+	err = listGenes(nil, []string{builtinProfile, invalidRegex})
+	if err == nil {
+		t.Errorf("Expected '%v' to be an invalid regex", invalidRegex)
+	}
+
+	err = listGenes(nil, []string{builtinProfile})
+	if err != nil {
+		t.Fail()
+	}
+
+	var validRegex = "3$"
+	err = listGenes(nil, []string{builtinProfile, validRegex})
+	if err != nil {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
As discussed in #10, this PR adds a sub-command to `nucamino profile` to list the genes available in built-in alignment profiles.